### PR TITLE
Update Python requirements to include Faust and version specs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-kafka-python
-python-schema-registry-client
+kafka-python==1.4.7
+python-schema-registry-client==1.2.7
+faust==1.10.4


### PR DESCRIPTION
When dusting off this demo and trying to run the `consumer_with_schema.py`, it failed with an error implying the `python-schema-registry-client` is dependent on the Faust Serializer in a way it wasn't in the past. Once I resolved the dependency issue, I realized that I could have avoided this problem if I'd locked in the version numbers in `requirements.txt`, so I've done that also here so we can ensure point-in-time stability.